### PR TITLE
Fix catppuccin colors

### DIFF
--- a/private_dot_config/nvim/lua/plugins/copilot.lua
+++ b/private_dot_config/nvim/lua/plugins/copilot.lua
@@ -1,4 +1,4 @@
-local colors = require("catppuccin.api.colors").get_colors()
+local colors = require("catppuccin.palettes").get_palette()
 vim.cmd("hi def CopilotSuggestion guifg=" .. colors.pink .. " ctermfg=244")
 vim.cmd("imap <silent><script><expr> <C-J> copilot#Accept('<CR>')")
 vim.cmd("let g:copilot_no_tab_map = v:true")

--- a/private_dot_config/nvim/lua/plugins/gitsigns.lua
+++ b/private_dot_config/nvim/lua/plugins/gitsigns.lua
@@ -1,4 +1,4 @@
-local colors = require("catppuccin.api.colors").get_colors()
+local colors = require("catppuccin.palettes").get_palette()
 vim.cmd("hi def GitSignsCurrentLineBlame guifg=" .. colors.overlay2 .. " ctermfg=244")
 
 require("gitsigns").setup({

--- a/private_dot_config/nvim/lua/plugins/nvim-tree.lua
+++ b/private_dot_config/nvim/lua/plugins/nvim-tree.lua
@@ -1,4 +1,4 @@
-local colors = require("catppuccin.api.colors").get_colors()
+local colors = require("catppuccin.palettes").get_palette()
 vim.cmd("highlight NvimTreeGitNew gui=NONE guifg=" .. colors.green .. " guibg=NONE")
 
 require("nvim-tree").setup({


### PR DESCRIPTION
Catppuccin colors are now in `'catppuccin.palettes'`.

Check this commit:
https://github.com/catppuccin/nvim/commit/7f718802b63de7badb3fec3150b345bb6b7674bb